### PR TITLE
サブディレクトリに移行した関係でMathjaxが読み込めなくなっている問題の修正

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -286,4 +286,4 @@ defaults:
       related: true
 
 after_footer_scripts:
-  - //cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
+  - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML


### PR DESCRIPTION
## PR概要

はじめまして、筑波大学のraspi0124と申します。
いつもNLP100本ノックで学習させていただいております。今回初めてPRさせていただきます。

### 本PRの目的

NLP100 2025年版の公開に伴い、2020年版が GitHub Pages 上で `https://nlp100.github.io/2020/` 以下の**サブディレクトリ**に移動されたことにより、プロトコル相対URL (`//cdn.mathjax.org/...`) を使っていた **MathJax** が正しく読み込まれなくなりました。

その結果、以下のように数式が崩れて表示される問題が発生しています：

```
現状の読み込み先: https://nlp100.github.io/2020//cdn.mathjax.org/...
→ MathJax の CDN にアクセスできず、数式が表示されない
```

本PRでは、URLを `https://cdn.mathjax.org/...` に書き換えることで、明示的にプロトコルを指定し、どのディレクトリでも安定して MathJax を読み込めるように修正しました。

---

## 1. 変更内容

* `_config.yml` における MathJax のURLをプロトコル相対から `https:` 明示に変更

```diff
- //cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
+ https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
```

---

## 2. 修正前の状態（数式が崩れている）

![image](https://github.com/user-attachments/assets/ab4a827f-0fcf-4079-ab02-c3b392bf022e)

---

## 3. 修正後の状態（数式が正しく表示される）

![image](https://github.com/user-attachments/assets/c16c1b48-5f7f-43dd-8b5d-3afe47ec8771)

---

お忙しいところ恐縮ですが、内容ご確認のうえ、マージをご検討いただけますと幸いです。
どうぞよろしくお願いいたします。